### PR TITLE
Do things right when `obj` is a tuple

### DIFF
--- a/compss/programming_model/bindings/python/src/pycompss/util/serialization/serializer.py
+++ b/compss/programming_model/bindings/python/src/pycompss/util/serialization/serializer.py
@@ -226,7 +226,7 @@ def serialize_to_handler(obj, handler):
         except AttributeError:
             # Bug fixed in 3.5 - issue10805
             pass
-        raise SerializerException('Cannot serialize object %s' % obj)
+        raise SerializerException('Cannot serialize object %r' % (obj,))
 
 
 @emit_event(SERIALIZE_TO_FILE_EVENT, master=False, inside=True)


### PR DESCRIPTION
When `obj` is a tuple, this raise yields a TypeError given that the formatting is not resolved.

The proper way of doing this is by ensuring that a tuple is being used for string formatting (in particular, a single element tuple).

And, on the way there, it's much better to use `%r` in this context, just in case `obj` is a complex object and has a non-trivial `__str__` method --while the `__repr__` method should be simpler. In a lot of scenarios this change is imperceptible, in others improves log messages a lot.